### PR TITLE
Add UserProfileData interface and tighten auth types

### DIFF
--- a/src/contexts/auth/types.ts
+++ b/src/contexts/auth/types.ts
@@ -1,5 +1,6 @@
 
 import { Session, User } from "@supabase/supabase-js";
+import { UserProfileData } from "@/types/user";
 
 export interface AuthContextType {
   user: User | null;
@@ -12,9 +13,15 @@ export interface AuthContextType {
   isRegistering: boolean;
   pendingSubscription: boolean;
   signIn: (email: string, password: string) => Promise<{ success: boolean; error?: any }>;
-  signUp: (email: string, password: string, userData?: any) => Promise<{ success: boolean; error?: any }>;
+  signUp: (
+    email: string,
+    password: string,
+    userData?: UserProfileData | Record<string, unknown>
+  ) => Promise<{ success: boolean; error?: any }>;
   signOut: () => Promise<void>;
-  updateProfile: (data: any) => Promise<any>;
+  updateProfile: (
+    data: UserProfileData | Record<string, unknown>
+  ) => Promise<any>;
   resetPassword: (email: string) => Promise<{ success: boolean; error?: any }>;
   setRegistrationData: (data: Partial<RegistrationData>) => void;
   clearRegistrationData: () => void;

--- a/src/hooks/useSecureAuth.ts
+++ b/src/hooks/useSecureAuth.ts
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '@/lib/supabase-client';
 import { Session, User, AuthError } from '@supabase/supabase-js';
+import { UserProfileData } from '@/types/user';
 
 export function useSecureAuth() {
   const [session, setSession] = useState<Session | null>(null);
@@ -83,7 +84,11 @@ export function useSecureAuth() {
     }
   };
 
-  const signUp = async (email: string, password: string, userData?: any) => {
+  const signUp = async (
+    email: string,
+    password: string,
+    userData?: UserProfileData | Record<string, unknown>
+  ) => {
     try {
       const { data, error: signUpError } = await supabase.auth.signUp({
         email,
@@ -120,7 +125,9 @@ export function useSecureAuth() {
     }
   };
 
-  const updateProfile = async (userData: any) => {
+  const updateProfile = async (
+    userData: UserProfileData | Record<string, unknown>
+  ) => {
     try {
       const { data, error: updateError } = await supabase.auth.updateUser({
         data: userData

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,12 @@
+export interface UserProfileData {
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  city?: string;
+  street?: string;
+  postalCode?: string;
+  country?: string;
+  birthDate?: string;
+  idNumber?: string;
+  [key: string]: unknown;
+}


### PR DESCRIPTION
## Summary
- introduce `UserProfileData` interface for optional profile fields
- use this type in secure auth hooks
- update auth context types to avoid `any`

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Argument of type '"payment_history"' is not assignable to parameter of type ...)*
- `npm run lint` *(fails: 445 errors)*