### PR TITLE
Fix service worker registration in development

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,9 +12,11 @@ window.__VITE_TIMESTAMP__ = Date.now();
 
 // Make sure the DOM is fully loaded before initializing React
 document.addEventListener('DOMContentLoaded', () => {
-  // Initialize the service worker
-  initializeServiceWorker();
-  
+  // Register the service worker only in production to avoid caching issues in development
+  if (import.meta.env.PROD) {
+    initializeServiceWorker();
+  }
+
   // Initialize the React application
   initializeApp();
 });


### PR DESCRIPTION
## Summary
- avoid caching issues by registering the service worker only in production

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*