### PR TITLE
Fix token saving on Cardcom webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,16 @@ We don't support custom domains (yet). If you want to deploy your project under 
 Recent database migrations can be found in `supabase/migrations`.
 
 - `20250410120000_add_unique_constraint_profiles_phone.sql` adds a unique constraint to the `profiles.phone` column.
+
+## Recovering Missing Payment Tokens
+
+Occasionally a Cardcom webhook may be logged without storing the payment token in
+`recurring_payments`. Run the script below to reprocess any webhook entries that
+did not create a token or remain unprocessed:
+
+```sh
+npm run ts-node scripts/reprocess-missing-tokens.ts
+```
+
+The script scans `payment_webhooks` for token information and invokes the
+`process-webhook` function for any records lacking a corresponding token entry.

--- a/scripts/reprocess-missing-tokens.ts
+++ b/scripts/reprocess-missing-tokens.ts
@@ -15,8 +15,8 @@ const supabase = createClient(supabaseUrl, supabaseKey, {
 async function run() {
   const { data: webhooks, error } = await supabase
     .from("payment_webhooks")
-    .select("id, payload")
-    .eq("processed", true);
+    .select("id, payload, processed")
+    .order("created_at", { ascending: false });
 
   if (error) {
     console.error("Error fetching webhooks", error);
@@ -42,7 +42,7 @@ async function run() {
       continue;
     }
 
-    if (!existingToken) {
+    if (!existingToken || webhook.processed === false) {
       console.log(`Reprocessing webhook ${webhook.id} for token ${token}`);
       await supabase.functions.invoke("process-webhook", {
         body: { webhookId: webhook.id },

--- a/supabase/functions/process-payment-data/index.ts
+++ b/supabase/functions/process-payment-data/index.ts
@@ -100,7 +100,9 @@ serve(async (req) => {
             user_id: userId,
             token: tokenInfo.Token,
             token_expiry: tokenExpiry,
-            token_approval_number: tokenInfo.TokenApprovalNumber,
+            // Some Cardcom responses may omit TokenApprovalNumber even on success.
+            // Default to empty string to satisfy NOT NULL constraints.
+            token_approval_number: tokenInfo.TokenApprovalNumber || "",
             last_4_digits: transactionInfo?.Last4CardDigits || null,
             card_type: transactionInfo?.CardInfo || null,
             status: "active",

--- a/supabase/functions/process-webhook/index.ts
+++ b/supabase/functions/process-webhook/index.ts
@@ -280,7 +280,9 @@ serve(async (req) => {
                 user_id: effectiveUserId,
                 token: tokenInfo.Token,
                 token_expiry: parseCardcomDateString(tokenInfo.TokenExDate),
-                token_approval_number: tokenInfo.TokenApprovalNumber,
+                // TokenApprovalNumber may be missing in some webhook payloads.
+                // Use empty string to avoid violating NOT NULL constraints.
+                token_approval_number: tokenInfo.TokenApprovalNumber || "",
                 last_4_digits: transactionInfo?.Last4CardDigits || null,
                 card_type: transactionInfo?.CardInfo || null,
                 status: 'active',


### PR DESCRIPTION
## Summary
- ensure `token_approval_number` is never null when saving Cardcom tokens
- extend reprocess-missing-tokens script to handle unprocessed webhooks
- document how to recover missing payment tokens

## Testing
- `npm run lint` *(fails: many existing lint errors)*