### PR TITLE
Use upsert for recurring payments

### DIFF
--- a/supabase/functions/cardcom-webhook/index.ts
+++ b/supabase/functions/cardcom-webhook/index.ts
@@ -400,7 +400,7 @@ async function processUserPayment(supabase: any, userId: string, payload: any) {
       // Save the token to recurring_payments
       const { error: tokenError } = await supabase
         .from("recurring_payments")
-        .insert({
+        .upsert({
           user_id: userId,
           token: tokenInfo.Token,
           token_expiry: tokenExpiry,
@@ -409,7 +409,7 @@ async function processUserPayment(supabase: any, userId: string, payload: any) {
           card_type: transactionInfo?.CardInfo || null,
           status: "active",
           is_valid: true,
-        });
+        }, { onConflict: "token" });
 
       if (tokenError) {
         console.error("Error storing token:", tokenError);

--- a/supabase/functions/process-payment-data/index.ts
+++ b/supabase/functions/process-payment-data/index.ts
@@ -96,7 +96,7 @@ serve(async (req) => {
         // Save the token to recurring_payments
         const { error: tokenError } = await supabaseClient
           .from("recurring_payments")
-          .insert({
+          .upsert({
             user_id: userId,
             token: tokenInfo.Token,
             token_expiry: tokenExpiry,
@@ -107,7 +107,7 @@ serve(async (req) => {
             card_type: transactionInfo?.CardInfo || null,
             status: "active",
             is_valid: true,
-          });
+          }, { onConflict: "token" });
 
         if (tokenError) {
           console.error("Error storing token:", tokenError);


### PR DESCRIPTION
## Summary
- avoid duplicate records on recurring payments by using upsert
- handle upsert errors when storing payment tokens

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any issues)*