### PR TITLE
Add cron job for reprocessing missing tokens

### DIFF
--- a/.github/workflows/reprocess-missing-tokens.yml
+++ b/.github/workflows/reprocess-missing-tokens.yml
@@ -1,0 +1,25 @@
+name: Reprocess Missing Payment Tokens
+
+on:
+  schedule:
+    # Run daily at 1:30 AM UTC
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+      - name: Run reprocess script
+        run: npx ts-node scripts/reprocess-missing-tokens.ts
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+

--- a/README.md
+++ b/README.md
@@ -81,8 +81,19 @@ Occasionally a Cardcom webhook may be logged without storing the payment token i
 did not create a token or remain unprocessed:
 
 ```sh
-npm run ts-node scripts/reprocess-missing-tokens.ts
+npx ts-node scripts/reprocess-missing-tokens.ts
 ```
 
 The script scans `payment_webhooks` for token information and invokes the
 `process-webhook` function for any records lacking a corresponding token entry.
+
+### Automated reprocessing
+
+A GitHub Actions workflow runs the same script every day at **1:30&nbsp;AM UTC**.
+The workflow requires the following secrets to connect to Supabase:
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+Ensure these secrets are defined in the repository settings so the scheduled job
+can execute successfully.


### PR DESCRIPTION
## Summary
- run reprocess-missing-tokens.ts on a daily schedule
- document the automatic reprocessing job
- show how to run the script manually with `npx ts-node`

## Testing
- `npm run lint` *(fails: Parsing error and unused vars)*